### PR TITLE
Use GitHub Actions for releasing gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+    - uses: actions/setup-ruby@v1
+      with: 
+        ruby-version: '2.6'
+        
+    - name: Get version from latest tag
+      id: get_version
+      uses: battila7/get-version-action@v2
+
+    - name: Bump version    
+      run: |
+        gem install -N gem-release
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        gem bump --skip-ci --version ${{ steps.get_version.outputs.version-without-v }}
+        git push origin HEAD:master
+        
+    - name: Release gem to rubygems.org    
+      run: |
+        set +x
+        mkdir -p ~/.gem
+        cat << EOF > ~/.gem/credentials
+        ---
+        :rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
+        EOF
+        chmod 0600 ~/.gem/credentials
+        set -x
+        gem release


### PR DESCRIPTION
The workflow will:

- Use the latest tag as the new version
- Bump the version
- Release to rubygems.org