### PR TITLE
Use a PAT to push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,13 @@ jobs:
       id: get_version
       uses: battila7/get-version-action@v2
 
-    - name: Bump version    
+    - name: Bump version   
+      env:
+        # GitHub Actions token does not support pushing to protected branches.
+        # A manually populated`PERSONAL_ACCESS_TOKEN` environment variable 
+        # with permissions to push to a protected branch must be used.
+        # not ideal - keep eyes open for a better solution
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }} 
       run: |
         gem install -N gem-release
         git config --local user.email "action@github.com"


### PR DESCRIPTION
GitHub Actions cannot push to protected branches. Use a Personal Access Token with enough permissions instead.