### PR TITLE
Allow doc-order notification to accept params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,8 +141,6 @@ Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
   Enabled: false
-Style/OptionalBooleanParameter:
-  Enabled: false
 
 RSpec/NestedGroups:
   Max: 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,6 +141,8 @@ Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
   Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
 
 RSpec/NestedGroups:
   Max: 5

--- a/lib/finapps/rest/documents_orders_notifications.rb
+++ b/lib/finapps/rest/documents_orders_notifications.rb
@@ -3,11 +3,11 @@
 module FinApps
   module REST
     class DocumentsOrdersNotifications < FinAppsCore::REST::Resources
-      def create(id)
+      def create(id, params = [])
         not_blank(id, :id)
 
         path = "documents/orders/#{ERB::Util.url_encode(id)}/notify"
-        super nil, path
+        super params, path
       end
     end
   end

--- a/spec/rest/documents_orders_notifications_spec.rb
+++ b/spec/rest/documents_orders_notifications_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FinApps::REST::DocumentsOrdersNotifications do
     end
 
     context 'when invalid id is provided' do
-      let(:create) { subject.create(:invalid_id) }
+      let(:create) { subject.create(:invalid_id, ['1234']) }
       let(:results) { create[RESULTS] }
       let(:error_messages) { create[ERROR_MESSAGES] }
 
@@ -30,7 +30,7 @@ RSpec.describe FinApps::REST::DocumentsOrdersNotifications do
     end
 
     context 'with valid id' do
-      let(:create) { subject.create(:valid_id) }
+      let(:create) { subject.create(:valid_id, ['1234']) }
       let(:results) { create[RESULTS] }
       let(:error_messages) { create[ERROR_MESSAGES] }
 


### PR DESCRIPTION
Sending out a notification on a document order should now take an array of consumer public IDs.