### PR TITLE
Implement the retrieve document order by token endpoint

### DIFF
--- a/lib/finapps/rest/documents_orders.rb
+++ b/lib/finapps/rest/documents_orders.rb
@@ -17,7 +17,12 @@ module FinApps
 
       def show(id)
         not_blank(id, :order_id)
-        super(id, "documents/orders/#{id}")
+
+        if matches_token_format?(id)
+          show_by_token id
+        else
+          show_by_id id
+        end
       end
 
       def create(params)
@@ -44,6 +49,20 @@ module FinApps
       end
 
       private
+
+      def show_by_id(id)
+        path = "documents/orders/#{id}"
+        send_request path, :get
+      end
+
+      def show_by_token(jwt)
+        path = "documents/retrieve_order?token=#{jwt}"
+        send_request path, :get
+      end
+
+      def matches_token_format?(str)
+        str.match(/^.+\..+\..+$/)
+      end
 
       def build_filter(params)
         search_query(params[:searchTerm])

--- a/spec/rest/documents_orders_spec.rb
+++ b/spec/rest/documents_orders_spec.rb
@@ -134,14 +134,27 @@ RSpec.describe FinApps::REST::DocumentsOrders do
     let(:error_messages) { show[1] }
 
     context 'with valid id' do
-      let(:id) { :valid_order_id }
+      context 'when id is an identifier' do
+        let(:id) { :valid_order_id }
 
-      it_behaves_like 'an API request'
-      it_behaves_like 'a successful request'
-      it('results is a Hash') { expect(results).to be_a(Hash) }
+        it_behaves_like 'an API request'
+        it_behaves_like 'a successful request'
+        it('has an order_id node in the response') do
+          expect(results).to have_key(:order_id)
+        end
+      end
 
-      it('performs a get and returns the response') do
-        expect(results).to have_key(:order_id)
+      context 'when id is a token' do
+        let(:id) { '0123456abc.0123456abc.0123456abc' }
+
+        it_behaves_like 'an API request'
+        it_behaves_like 'a successful request'
+        it('has an order node in the response') do
+          expect(results).to have_key(:order)
+        end
+        it('has a consumer node in the response') do
+          expect(results).to have_key(:consumer)
+        end
       end
     end
 

--- a/spec/rest/documents_orders_spec.rb
+++ b/spec/rest/documents_orders_spec.rb
@@ -152,6 +152,7 @@ RSpec.describe FinApps::REST::DocumentsOrders do
         it('has an order node in the response') do
           expect(results).to have_key(:order)
         end
+
         it('has a consumer node in the response') do
           expect(results).to have_key(:consumer)
         end

--- a/spec/support/fake_api.rb
+++ b/spec/support/fake_api.rb
@@ -214,6 +214,9 @@ module Fake
     get("/#{version}/documents/orders/valid_order_id") do
       json_response 200, 'documents_order.json'
     end
+    get("/#{version}/documents/retrieve_order") do
+      json_response 200, 'documents/retrieve_order.json'
+    end
     get("/#{version}/documents/orders/invalid_order_id") do
       json_response 404, 'resource_not_found.json'
     end

--- a/spec/support/fixtures/documents/retrieve_order.json
+++ b/spec/support/fixtures/documents/retrieve_order.json
@@ -1,0 +1,97 @@
+{
+  "order": {
+    "order_id": "2eaf91ab-fdc3-4e0e-a614-5bc790771dcc",
+    "consumer_id": "4040e594-a1c7-4a9a-7a85-d78b915b5ac8",
+    "applicant": {
+      "public_id": "4040e594-a1c7-4a9a-7a85-d78b915b5ac8",
+      "email": "erich+202012301310@financialapps.com",
+      "first_name": "Erich",
+      "last_name": "Quintero",
+      "phone": "",
+      "external_id": ""
+    },
+    "reference_no": "20201230",
+    "esign_documents": [
+      {
+        "signature_request_id": "1fb7b6ad7ad31cff806c66da1ab449f1ed0f8e2a",
+        "completed": false,
+        "completed_date": null,
+        "declined": false,
+        "declined_date": null,
+        "declined_reason": null,
+        "declined_role": null,
+        "date_requested": "2020-12-30T18:11:41.907Z",
+        "template_name": "Un-Ordered Signing w/ Sender Field",
+        "template_id": "aefba323382586b15ede625b055243d94feb0693",
+        "is_ordered": false,
+        "custom_field": [
+          {
+            "api_id": "5ffc1866-c2fb-454c-ac60-37f87cc4fe3f",
+            "value": ""
+          }
+        ],
+        "signers": [
+          {
+            "public_id": "1031ae95-73c2-437d-7d89-b0834866ea63",
+            "role_name": "signer_1",
+            "signed": false,
+            "signed_date": null,
+            "signature_id": "6b5b8c3f0b7ab3a14a9a560c156a85f6"
+          },
+          {
+            "public_id": "032d6613-baa8-4419-60fd-28a3593cbd7a",
+            "role_name": "signer_2",
+            "signed": false,
+            "signed_date": null,
+            "signature_id": "0ef748f8ac3d1c80c0132097eb3a7af5"
+          }
+        ]
+      }
+    ],
+    "co_applicants": [
+      {
+        "public_id": "1031ae95-73c2-437d-7d89-b0834866ea63",
+        "email": "erich+202012301310-s1@financialapps.com",
+        "first_name": "Signer",
+        "last_name": "Uno",
+        "phone": "",
+        "external_id": ""
+      },
+      {
+        "public_id": "032d6613-baa8-4419-60fd-28a3593cbd7a",
+        "email": "erich+202012301310-s2@financialapps.com",
+        "first_name": "Signer",
+        "last_name": "Dos",
+        "phone": "",
+        "external_id": ""
+      }
+    ],
+    "upload_documents": [],
+    "tag": "new",
+    "status": 1,
+    "history": [
+      {
+        "date": "2020-12-30T18:11:44Z",
+        "event": "signature_request_sent",
+        "signature_request_id": "1fb7b6ad7ad31cff806c66da1ab449f1ed0f8e2a"
+      }
+    ],
+    "created_by": "erich@financialapps.com",
+    "date_created": "2020-12-30T18:11:40.156Z",
+    "date_modified": "2020-12-30T18:11:40.156Z",
+    "date_last_completed": null
+  },
+  "consumer": {
+    "public_id": "4040e594-a1c7-4a9a-7a85-d78b915b5ac8",
+    "email": "erich+202012301310@financialapps.com",
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwdWJsaWNfaWQiOiI0MDQwZTU5NC1hMWM3LTRhOWEtN2E4NS1kNzhiOTE1YjVhYzgiLCJzZXNzaW9uX2lkIjoiMzljNWJiZWYtMmRlMy00YTM1LTRiMjYtNDk1NThhYWFjMjcwIiwidXNlcl90eXBlIjoxLCJ0ZW5hbnRfaWQiOiI0ZGQ2MDdiMS01NjVmLTRkYTQtNzIyYy0yZTg0YzVjODdmNDMiLCJleHAiOjE2MDk0NDI5MDAsImlhdCI6MTYwOTM1NjUwMCwiaXNzIjoiRmluYW5jaWFsQXBwcyIsIm5iZiI6MTYwOTM1NjUwMH0.j66bynp-bVNIvrhv1AQO-mZgERu365BoyMMoppGGJo0",
+    "first_name": "Erich",
+    "last_name": "Quintero",
+    "memo": "",
+    "tenant_id": "4dd607b1-565f-4da4-722c-2e84c5c87f43",
+    "date_modified": "2020-12-30T18:11:40.167Z",
+    "date_created": "2020-12-30T18:11:40.167Z",
+    "locked": false,
+    "postal_code": "00000"
+  }
+}


### PR DESCRIPTION
Augment the current implementation to retrieve by `token` if the
parameter looks like a JWT or by `order_id` otherwise.