### PR TITLE
Add screenings schemas by tenant endpoint

### DIFF
--- a/lib/finapps/rest/screenings.rb
+++ b/lib/finapps/rest/screenings.rb
@@ -15,7 +15,7 @@ module FinApps
       end
 
       def tenant_schemas
-        path = "schemas"
+        path = 'schemas'
         send_request path, :get
       end
 

--- a/lib/finapps/rest/screenings.rb
+++ b/lib/finapps/rest/screenings.rb
@@ -14,6 +14,11 @@ module FinApps
         super(nil, path)
       end
 
+      def tenant_schemas
+        path = "schemas"
+        send_request path, :get
+      end
+
       def last(consumer_id)
         not_blank(consumer_id, :consumer_id)
 

--- a/spec/rest/screenings_spec.rb
+++ b/spec/rest/screenings_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe FinApps::REST::Screenings do
     end
   end
 
+  describe '#tenant_schemas' do
+    subject(:tenant_schemas) { described_class.new(client).tenant_schemas }
+
+    it_behaves_like 'an API request'
+    it_behaves_like 'a successful request'
+    it 'performs a get and returns the response' do
+      expect(results[0]).to have_key(:external_url)
+    end
+    it 'sends proper request' do
+      tenant_schemas
+      url = "#{versioned_api_path}/schemas"
+
+      expect(WebMock).to have_requested(:get, url)
+    end
+  end
+
   describe '#show' do
     subject(:show) { described_class.new(client).show(id) }
 

--- a/spec/rest/screenings_spec.rb
+++ b/spec/rest/screenings_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe FinApps::REST::Screenings do
     it 'performs a get and returns the response' do
       expect(results[0]).to have_key(:external_url)
     end
+
     it 'sends proper request' do
       tenant_schemas
       url = "#{versioned_api_path}/schemas"

--- a/spec/support/fixtures/screenings/tenant_schemas.json
+++ b/spec/support/fixtures/screenings/tenant_schemas.json
@@ -1,0 +1,8 @@
+[
+    {
+        "id": "6058c9e67d4ee100015d55e2",
+        "name": "Florida Family Medicaid Eligibility",
+        "description": "Screens applicants for Potential Family Medicaid Eligibility in the State of Florida.",
+        "external_url": ""
+    }
+]

--- a/spec/support/screenings_routes.rb
+++ b/spec/support/screenings_routes.rb
@@ -15,6 +15,9 @@ module Fake
 
       def list_routes(base, resource)
         base.get(resource) { json_response 200, 'screening_list.json' }
+        base.get(resource.gsub('screenings', 'schemas')) do
+          json_response 200, 'screenings/tenant_schemas.json'
+        end
         base.get("#{resource}/:consumer_id/consumer") do
           if params[:consumer_id] == 'invalid_consumer_id'
             json_response 404, 'session_not_found.json'

--- a/spec/support/screenings_routes.rb
+++ b/spec/support/screenings_routes.rb
@@ -13,6 +13,7 @@ module Fake
         create_routes base, resource
       end
 
+      # rubocop:disable Metrics/MethodLength
       def list_routes(base, resource)
         base.get(resource) { json_response 200, 'screening_list.json' }
         base.get(resource.gsub('screenings', 'schemas')) do
@@ -26,6 +27,7 @@ module Fake
           end
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def resume_routes(base, resource)
         base.get("#{resource}/:session_id/resume") do


### PR DESCRIPTION
Implement the [List Screening Schemas for a Tenant](https://qa-api.finclear.io:8080/docs#operation/TenantScreeningSchemaList) endpoint in the ruby client.

Expected response should be of the form:

```json
[
    {
        "id": "6058c9e67d4ee100015d55e2",
        "name": "Florida Family Medicaid Eligibility",
        "description": "Screens applicants for Medicaid Eligibility in FL.",
        "external_url": ""
    }
]
```