### PR TITLE
Add operator names to term_array

### DIFF
--- a/lib/finapps/rest/screenings.rb
+++ b/lib/finapps/rest/screenings.rb
@@ -95,9 +95,9 @@ module FinApps
       end
 
       def operator_filter(operator_id)
-        return {} unless operator_id 
-        
-        {'operator_id': operator_id}
+        return {} unless operator_id
+
+        {operator_id: operator_id}
       end
 
       def date_range_filter(from_date, to_date)

--- a/lib/finapps/rest/screenings.rb
+++ b/lib/finapps/rest/screenings.rb
@@ -86,6 +86,8 @@ module FinApps
         term.split.each do |t|
           arr.append('consumer.first_name': t)
           arr.append('consumer.last_name': t)
+          arr.append('operator.first_name': t)
+          arr.append('operator.last_name': t)
         end
 
         arr

--- a/lib/finapps/rest/screenings.rb
+++ b/lib/finapps/rest/screenings.rb
@@ -57,6 +57,7 @@ module FinApps
 
       def build_filter(params)
         term_filter(params[:searchTerm])
+          .merge(operator_filter(params[:operatorID]))
           .merge(date_range_filter(params[:fromDate], params[:toDate]))
           .merge(progress_filter(params[:progress]))
       end
@@ -91,6 +92,12 @@ module FinApps
         end
 
         arr
+      end
+
+      def operator_filter(operator_id)
+        return {} unless operator_id 
+        
+        {'operator_id': operator_id}
       end
 
       def date_range_filter(from_date, to_date)

--- a/lib/finapps/rest/screenings.rb
+++ b/lib/finapps/rest/screenings.rb
@@ -73,7 +73,9 @@ module FinApps
           {'consumer.email': term},
           {'consumer.first_name': term},
           {'consumer.last_name': term},
-          {'consumer.external_id': term}
+          {'consumer.external_id': term},
+          {'operator.first_name': term},
+          {'operator.last_name': term}
         ]
       end
 

--- a/spec/rest/screenings_spec.rb
+++ b/spec/rest/screenings_spec.rb
@@ -84,10 +84,16 @@ RSpec.describe FinApps::REST::Screenings do
                   {'consumer.first_name': 'le term'},
                   {'consumer.last_name': 'le term'},
                   {'consumer.external_id': 'le term'},
+                  {'operator.first_name': 'le term'},
+                  {'operator.last_name': 'le term'},
                   {'consumer.first_name': 'le'},
                   {'consumer.last_name': 'le'},
+                  {'operator.first_name': 'le'},
+                  {'operator.last_name': 'le'},
                   {'consumer.first_name': 'term'},
-                  {'consumer.last_name': 'term'}]
+                  {'consumer.last_name': 'term'},
+                  {'operator.first_name': 'term'},
+                  {'operator.last_name': 'term'}]
         }
       end
     end

--- a/spec/rest/screenings_spec.rb
+++ b/spec/rest/screenings_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe FinApps::REST::Screenings do
         let(:params) { {operatorID: '123abc'} }
 
         it_behaves_like 'a correct query builder', {
-          'operator_id': '123abc'
+          operator_id: '123abc'
         }
       end
     end

--- a/spec/rest/screenings_spec.rb
+++ b/spec/rest/screenings_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe FinApps::REST::Screenings do
                   {'operator.last_name': 'term'}]
         }
       end
+
+      context 'with operator' do
+        let(:params) { {operatorID: '123abc'} }
+
+        it_behaves_like 'a correct query builder', {
+          'operator_id': '123abc'
+        }
+      end
     end
 
     context 'with invalid params' do


### PR DESCRIPTION
- Adds `operator.first_name` and `operator.last_name` to `term_array` so that the user may enter the operator's name when performing a search on the Screening Report page
- Allows filtering by `operator_id`