### PR TITLE
Update location implementation to latest contract specifications

### DIFF
--- a/lib/finapps/rest/locations.rb
+++ b/lib/finapps/rest/locations.rb
@@ -8,9 +8,9 @@ module FinApps
         super path
       end
 
-      def update(key, params = {})
-        path = resource_path(key)
-        send_request path, :put, params
+      def update(id, params)
+        path = resource_path(id)
+        super params, path
       end
     end
   end

--- a/lib/finapps/rest/states.rb
+++ b/lib/finapps/rest/states.rb
@@ -3,6 +3,9 @@
 module FinApps
   module REST
     class States < FinAppsCore::REST::Resources # :nodoc:
+      def end_point
+        "references/#{super}"
+      end
     end
   end
 end

--- a/spec/rest/locations_spec.rb
+++ b/spec/rest/locations_spec.rb
@@ -5,6 +5,8 @@ require 'digest'
 RSpec.describe FinApps::REST::Locations do
   include SpecHelpers::Client
 
+  let(:id) { :id }
+
   describe '#list' do
     subject(:list) { described_class.new(client).list filter }
 
@@ -12,6 +14,7 @@ RSpec.describe FinApps::REST::Locations do
 
     it_behaves_like 'an API request'
     it_behaves_like 'a successful request'
+    it { expect(list[RESULTS]).to all(have_key(:id)) }
     it { expect(list[RESULTS]).to all(have_key(:name)) }
     it { expect(list[RESULTS]).to all(have_key(:state)) }
 
@@ -41,72 +44,47 @@ RSpec.describe FinApps::REST::Locations do
   end
 
   describe '#show' do
-    subject(:show) { described_class.new(client).show(key) }
-
-    let(:key) { Digest::SHA256.hexdigest('Quick Mart Urgent CareMD,MD') }
+    subject(:show) { described_class.new(client).show(id) }
 
     it_behaves_like 'an API request'
     it_behaves_like 'a successful request'
+    it { expect(show[RESULTS]).to have_key(:id) }
     it { expect(show[RESULTS]).to have_key(:name) }
     it { expect(show[RESULTS]).to have_key(:state) }
 
-    context 'when key is not a valid SHA256' do
-      let(:key) { 'invalid_SHA256' }
+    context 'when id does not match any location' do
+      let(:id) { 'not_found' }
 
-      it_behaves_like 'a failed request'
-    end
-
-    context 'when key does not match any location' do
-      let(:key) { 'not_found' }
-
-      it_behaves_like 'a failed request'
       it_behaves_like 'a request to a not found resource'
     end
   end
 
   describe '#update' do
-    subject(:update) { described_class.new(client).update(key, params) }
+    subject(:update) { described_class.new(client).update(id, params) }
 
-    let(:key) { Digest::SHA256.hexdigest('Quick Mart Urgent CareMD,MD') }
     let(:params) { {name: 'Quick Mart Non-Urgent Care', state: {code: 'MD'}} }
 
     it_behaves_like 'an API request'
     it_behaves_like 'a successful request'
     it { expect(update[RESULTS]).to be_nil }
 
-    context 'when key is not a valid SHA256' do
-      let(:key) { 'invalid_SHA256' }
+    context 'when id does not match any location' do
+      let(:id) { 'not_found' }
 
-      it_behaves_like 'a failed request'
-    end
-
-    context 'when key does not match any location' do
-      let(:key) { 'not_found' }
-
-      it_behaves_like 'a failed request'
       it_behaves_like 'a request to a not found resource'
     end
   end
 
   describe '#destroy' do
-    subject(:destroy) { described_class.new(client).destroy(key) }
-
-    let(:key) { Digest::SHA256.hexdigest('Quick Mart Urgent CareMD,MD') }
+    subject(:destroy) { described_class.new(client).destroy(id) }
 
     it_behaves_like 'an API request'
     it_behaves_like 'a successful request'
     it { expect(destroy[RESULTS]).to be_nil }
 
-    context 'when key is not a valid SHA256' do
-      let(:key) { 'invalid_SHA256' }
+    context 'when id does not match any location' do
+      let(:id) { 'not_found' }
 
-      it_behaves_like 'a failed request'
-    end
-
-    context 'when key does not match any location' do
-      let(:key) { 'not_found' }
-
-      it_behaves_like 'a failed request'
       it_behaves_like 'a request to a not found resource'
     end
   end

--- a/spec/rest/states_spec.rb
+++ b/spec/rest/states_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe FinApps::REST::States do
     it_behaves_like 'an API request'
     it_behaves_like 'a successful request'
 
-    it('returns a list') { expect(list[RESULTS]).to be_a(Array) }
+    it('returns a list of hashes with the following keys: code, label, type') do
+      expect(list[RESULTS].first.keys).to match_array(%i[code label type])
+    end
   end
 end

--- a/spec/support/fixtures/locations/get_location.json
+++ b/spec/support/fixtures/locations/get_location.json
@@ -1,4 +1,5 @@
 {
+  "id": "2c0c2951-0a5e-463f-abd3-d315e63a62b2",
   "name": "IK",
   "state": {
     "code": "MD",

--- a/spec/support/fixtures/locations/get_locations.json
+++ b/spec/support/fixtures/locations/get_locations.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "2c0c2951-0a5e-463f-abd3-d315e63a62b2",
     "name": "Quick Mart Urgent Care",
     "state": {
       "code": "MD",
@@ -8,6 +9,7 @@
     }
   },
   {
+    "id": "2c0c2951-0a5e-463f-abd3-d315e63a62b3",
     "name": "Quick Mart Emergency Room",
     "state": {
       "code": "MD",
@@ -16,6 +18,7 @@
     }
   },
   {
+    "id": "2c0c2951-0a5e-463f-abd3-d315e63a62b4",
     "name": "Quick Mart - Folsom Business Office",
     "state": {
       "code": "CA",

--- a/spec/support/routes/locations.rb
+++ b/spec/support/routes/locations.rb
@@ -19,18 +19,16 @@ module Fake
       end
 
       def delete_routes(base)
-        base.delete("/#{base.version}/locations/:key") do
-          return status(404) if params[:key] == 'not_found'
-          return status(400) unless sha256?(params[:key])
+        base.delete("/#{base.version}/locations/:id") do
+          return status(404) if params[:id] == 'not_found'
 
           status 204
         end
       end
 
       def put_routes(base)
-        base.put("/#{base.version}/locations/:key") do
-          return status(404) if params[:key] == 'not_found'
-          return status(400) unless sha256?(params[:key])
+        base.put("/#{base.version}/locations/:id") do
+          return status(404) if params[:id] == 'not_found'
 
           status 204
         end
@@ -42,17 +40,12 @@ module Fake
 
           json_response 200, 'locations/get_locations.json'
         end
-        base.get("/#{base.version}/locations/:key") do
-          return status(404) if params[:key] == 'not_found'
-          return status(400) unless sha256?(params[:key])
+        base.get("/#{base.version}/locations/:id") do
+          return status(404) if params[:id] == 'not_found'
 
           json_response 200, 'locations/get_location.json'
         end
       end
-    end
-
-    def sha256?(key)
-      key.length == 64 && key.match(/^[0-9a-f]+$/)
     end
   end
 end

--- a/spec/support/routes/states.rb
+++ b/spec/support/routes/states.rb
@@ -4,7 +4,7 @@ module Fake
   module StateRoutes
     class << self
       def included(base)
-        base.get("/#{base.version}/states") do
+        base.get("/#{base.version}/references/states") do
           json_response 200, 'states/get_states.json'
         end
         super


### PR DESCRIPTION
- Use `id` instead of `key` to identify locations.
- States endpoint changed to `references/states'.